### PR TITLE
Add editable defaults so we can configure global usage

### DIFF
--- a/jquery.html5-placeholder-shim.js
+++ b/jquery.html5-placeholder-shim.js
@@ -6,14 +6,14 @@
           this._supported :
           ( this._supported = !!('placeholder' in $('<input type="text">')[0]) );
       },
+      defaults: {
+        color: '#888',
+        cls: 'placeholder',
+        selector: 'input[placeholder], textarea[placeholder]'
+      },
       shim: function(opts) {
-        var config = {
-          color: '#888',
-          cls: 'placeholder',
-          selector: 'input[placeholder], textarea[placeholder]'
-        };
-        $.extend(config,opts);
-        !this.browser_supported() && $(config.selector)._placeholder_shim(config);
+        opts = $.extend({},this.defaults,opts);
+        !this.browser_supported() && $(opts.selector)._placeholder_shim(opts);
       }
   }});
 


### PR DESCRIPTION
This commit adds editable default settings, so we can configure the default global usage. Example usage:

``` javascript
// fix conflict with select2
$.placeholder.defaults.selector = 'input[placeholder]:not(.auto-complete-hidden), textarea[placeholder]';
```
